### PR TITLE
adds the capability to change what is shown for each stock

### DIFF
--- a/yahoostocks@fthuin/desklet.js
+++ b/yahoostocks@fthuin/desklet.js
@@ -36,6 +36,20 @@ StockQuoteDesklet.prototype = {
         this.settings.bindProperty(Settings.BindingDirection.IN, "width", "width", this.onDisplayChanged, null);
         this.settings.bindProperty(Settings.BindingDirection.IN, "delayMinutes", "delayMinutes", this.onSettingsChanged, null);
         this.settings.bindProperty(Settings.BindingDirection.IN, "companySymbols", "companySymbolsText", this.onSettingsChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showIcon", "showIcon", this.onSettingsChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showStockName", "showStockName", this.onSettingsChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showStockSymbol", "showStockSymbol", this.onSettingsChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showStockPrice", "showStockPrice", this.onSettingsChanged, null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, "showStockPercentChange", "showStockPercentChange", this.onSettingsChanged, null);
+    },
+    getQuoteDisplaySettings: function() {
+      return {
+          "icon": this.showIcon,
+          "stockName": this.showStockName,
+          "stockTicker": this.showStockSymbol,
+          "stockPrice": this.showStockPrice,
+          "percentChange": this.showStockPercentChange
+      };
     },
     onDisplayChanged: function () {
         this.resize();
@@ -63,7 +77,7 @@ StockQuoteDesklet.prototype = {
     },
     render: function (stockQuotes) {
         var table = new StockQuotesTable();
-        table.render(stockQuotes);
+        table.render(stockQuotes, this.getQuoteDisplaySettings());
 
         var tableContainer = new St.BoxLayout({
             vertical: true
@@ -110,19 +124,30 @@ StockQuotesTable.prototype = {
         GBP: "\u00A3",
         INR: "\u20A8"
     },
-    render: function (stockQuotes) {
+    render: function (stockQuotes, settings) {
         for (var rowIndex = 0, l = stockQuotes.length; rowIndex < l; rowIndex++)
-            this.renderTableRow(stockQuotes[rowIndex], rowIndex);
+            this.renderTableRow(stockQuotes[rowIndex], rowIndex, settings);
     },
-    renderTableRow: function (stockQuote, rowIndex) {
-        var cellContents = [
-            this.createPercentChangeIcon(stockQuote),
-            this.createCompanyNameLabel(stockQuote),
-            this.createStockSymbolLabel(stockQuote),
-            this.createStockPriceLabel(stockQuote),
-            this.createPercentChangeLabel(stockQuote)
-        ];
+    renderTableRow: function (stockQuote, rowIndex, shouldShow) {
 
+        var cellContents = [];
+
+        if (shouldShow.icon) {
+            cellContents.push(this.createPercentChangeIcon(stockQuote));
+        }
+        if (shouldShow.stockName) {
+            cellContents.push(this.createCompanyNameLabel(stockQuote));
+        }
+        if (shouldShow.stockTicker) {
+            cellContents.push(this.createStockSymbolLabel(stockQuote));
+        }
+        if (shouldShow.stockPrice) {
+            cellContents.push(this.createStockPriceLabel(stockQuote));
+        }
+        if (shouldShow.percentChange) {
+            cellContents.push(this.createPercentChangeLabel(stockQuote));
+        }
+        
         for (var columnIndex = 0; columnIndex < cellContents.length; ++columnIndex)
             this.el.add(cellContents[columnIndex], {
                 row: rowIndex,

--- a/yahoostocks@fthuin/settings-schema.json
+++ b/yahoostocks@fthuin/settings-schema.json
@@ -39,5 +39,42 @@
     "default": "AAPL\nABBV\nADSK\nAMZN\nBAC\nBBRY\nC\nDAL\nDANG\nDHR\nDIA\nEBAY\nEEM\nEN.PA\nEWJ\nFB\nFXE\nFXI\nGE\nGLD\nGOOG\nGRMN\nHPQ\nINTC\nIWM\nJD\nLNKD\nMMB.PA\nMPLX\nMRVL\nMSFT\nMWE\nMXL\nNBG\nQQQ\nRHT\nRIG\nSFUN\nSMH\nSPY\nSWIR\nT\nTWTR\nUNP\nUSO\nUTX\nUUP\nVXX\nXLF\nXOMA\nYELP\nYHOO",
     "description": "Company Symbol List :",
     "tooltip": "Write the company codes here separated with line-breaks."
+  },
+  "separator": {
+    "type": "separator"
+  },
+  "display": {
+    "type": "header",
+    "description": "Change what is visible for each stock"
+  },
+  "showIcon": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show up/down icon",
+    "tooltip": "Shows whether the stock price is up or down"
+  },
+  "showStockName": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show full stock name",
+    "tooltip": "Shows the full stock name (eg Microsoft Corporation)"
+  },
+  "showStockSymbol": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show stock ticker",
+    "tooltip": "Shows the stock ticker (eg MSFT)"
+  },
+  "showStockPrice": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show stock price",
+    "tooltip": "Shows the current stock price"
+  },
+  "showStockPercentChange": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show percent change",
+    "tooltip": "Shows the percent change in the stock price"
   }
 }


### PR DESCRIPTION
This pull request will allow users to configure what is shown for each stock quote.  It fixes https://github.com/fthuin/yahoofinance-cinnamon-desklet/issues/4

First, new settings are added to the `settings-schema.json` file.  

In `Desklet.js`:
- The new settings are bound
- A new `getQuoteDisplaySettings` function is added to the `StockQuoteDesklet` class
- The render function on the `StockQuoteDesklet` class is updated to pass the quote display settings
- The render function on the `StockQuotesTable` class is updated to pass the settings to `renderTableRow`
- The `renderTableRow` function is updated to see whether each item should be shown
